### PR TITLE
cmdstanpy 1.1.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ec416e2ce6bf9317a9edb5e105ee6f7a9c3ab19df360d57041993e90ed7c641a
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 1
   skip: true  # [py<37]
+  # Error: Bad CPU type in executable
+  skip: true  # [osx]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - install_cmdstan = cmdstanpy.install_cmdstan:main


### PR DESCRIPTION
cmdstanpy 1.1.0 

**Destination channel:** Defaults

### Links

- [PKG-11279]
- dev_url:        https://github.com/stan-dev/cmdstanpy
- conda_forge:    https://github.com/conda-forge/cmdstanpy-feedstock
- pypi:           https://pypi.org/project/cmdstanpy/latest
- pypi inspector: https://inspector.pypi.io/project/cmdstanpy/latest

### Explanation of changes:

- rebuild for py313 and py314
- skipping osx due to known bug on PBP


[PKG-11279]: https://anaconda.atlassian.net/browse/PKG-11279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ