### PR TITLE
cmdstanpy 1.3.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cmdstanpy" %}
-{% set version = "1.1.0" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,11 @@ package:
 
 source:
   url: https://github.com/stan-dev/cmdstanpy/archive/v{{ version }}.tar.gz
-  sha256: ec416e2ce6bf9317a9edb5e105ee6f7a9c3ab19df360d57041993e90ed7c641a
+  sha256: 02cbeeae5fc4145c383177062ec3eaa8deb32ae04b33b63db2ef9e65b7731d65
 
 build:
-  number: 1
-  skip: true  # [py<37]
-  # Error: Bad CPU type in executable
-  skip: true  # [osx]
+  number: 0
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - install_cmdstan = cmdstanpy.install_cmdstan:main
@@ -29,21 +27,38 @@ requirements:
     - python
     - pandas
     - numpy >=1.21
+    - stanio >=0.4.0,<2.0.0
     - cmdstan
     - tqdm
+  run_constrained:
+    - polars >=1.8.2
+
+# _pickle.PicklingError: Can't pickle <class 'cmdstanpy.stanfit.mcmc.CmdStanMCMC'>: 
+# it's not the same object as cmdstanpy.stanfit.mcmc.CmdStanMCMC
+{% set skip_tests = "--deselect=test/test_generate_quantities.py::test_serialization" %}
+{% set skip_tests = skip_tests + " --deselect=test/test_sample.py::test_serialization" %}
 
 test:
+  source_files:
+    - test
   imports:
     - cmdstanpy
     - cmdstanpy.stanfit
     - cmdstanpy.utils
   requires:
+    - git
     - pip
+    - pytest
+    - xarray
+
+  commands:
+    - pytest -v test {{ skip_tests }}
 
 about:
   home: https://mc-stan.org/users/interfaces/cmdstan.html
-  dev_url: https://github.com/stan-dev/cmdstanpy
-  doc_url: https://cmdstanpy.readthedocs.io
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.md
   summary: |
     CmdStanPy is a lightweight interface to Stan for Python users which
     provides the necessary objects and functions to compile a Stan program
@@ -53,9 +68,8 @@ about:
     It supports both development and production workflows. Because model development and testing may require many iterations, 
     the defaults favor development mode and therefore output files are stored on a temporary filesystem. 
     Non-default options allow all aspects of a run to be specified so that scripts can be used to distributed analysis jobs across nodes and machines.
-  license: BSD-3-Clause
-  license_family: BSD
-  license_file: LICENSE.md
+  dev_url: https://github.com/stan-dev/cmdstanpy
+  doc_url: https://cmdstanpy.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cmdstanpy 1.3.0 

**Destination channel:** Defaults

### Links

- [PKG-12966]
- dev_url:        https://github.com/stan-dev/cmdstanpy/tree/v1.3.0
- conda_forge:    https://github.com/conda-forge/cmdstanpy-feedstock
- pypi:           https://pypi.org/project/cmdstanpy/1.3.0
- pypi inspector: https://inspector.pypi.io/project/cmdstanpy/1.3.0

### Explanation of changes:

- new version number


[PKG-12966]: https://anaconda.atlassian.net/browse/PKG-12966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ